### PR TITLE
feat: add a healthcheck, remove duplicate test

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -15,8 +15,12 @@ COPY server/ server/
 RUN --mount=type=cache,target=/root/.cache/go-build \
     go build -o extproc-go examples/main.go
 
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    go build -o healthcheck examples/hack/healthcheck.go
+
 FROM gcr.io/distroless/base
 
 COPY --from=build --chown=nonroot:nonroot /build/extproc-go .
+COPY --from=build --chown=nonroot:nonroot /build/healthcheck .
 
 CMD ["./extproc-go"]

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -29,7 +29,7 @@ services:
             - "**/*.yml"
             - "**/*.yaml"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://extproc-go:8080/headers"]
+      test: ["CMD", "./healthcheck", "http://extproc-go:8080/headers"]
       interval: 5s
       timeout: 10s
       retries: 60

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -29,7 +29,7 @@ services:
             - "**/*.yml"
             - "**/*.yaml"
     healthcheck:
-      test: ["CMD", "./healthcheck", "http://extproc-go:8080/headers"]
+      test: ["CMD", "./healthcheck", "--url", "http://extproc-go:8080/headers", "--timeout", "10s"]
       interval: 5s
       timeout: 10s
       retries: 60

--- a/examples/filters/testdata/setcookie.yml
+++ b/examples/filters/testdata/setcookie.yml
@@ -1,4 +1,3 @@
----
 name: it should set set-cookie headers with SameSite=Lax and HttpOnly
 input:
   headers:

--- a/examples/hack/healthcheck.go
+++ b/examples/hack/healthcheck.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatalf("usage: %s <url>", os.Args[0])
+	}
+	url := os.Args[1]
+
+	r, err := http.Get(url)
+	if err != nil {
+		log.Fatalf("requesting %s: %w", url, err.Error())
+	}
+	defer r.Body.Close()
+
+	log.Printf("requesting %s -> %d", url, r.StatusCode)
+	if r.StatusCode >= 400 {
+		os.Exit(1)
+	}
+}

--- a/examples/hack/healthcheck.go
+++ b/examples/hack/healthcheck.go
@@ -22,13 +22,13 @@ func main() {
 		timeout = 5 * time.Second
 	}
 	if url == "" {
-		log.Fatalf("--url is a required argument")
+		log.Fatal("--url is a required argument")
 	}
 
 	client := http.Client{Timeout: timeout}
 	r, err := client.Get(url)
 	if err != nil {
-		log.Fatalf("requesting %s: %w", url, err.Error())
+		log.Fatalf("requesting %s: %s", url, err.Error())
 	}
 	defer r.Body.Close()
 


### PR DESCRIPTION
- distroless doesn't have curl so this adds a healthcheck that can run on distroless (could also use a non distroless image)

You can check via 
```
docker inspect --format "{{json .State.Health }}" examples-extproc-go-1  |  jq
```

```json
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2025-01-13T14:37:01.84518503+01:00",
      "End": "2025-01-13T14:37:01.94401428+01:00",
      "ExitCode": 0,
      "Output": "2025/01/13 13:37:01 requesting http://extproc-go:8080/headers -> 200\n"
    }
  ]
}
```

We were also running an empty test (assume that's not intended - that's what removing the `---` achieves)