### PR TITLE
[DEMO] setup multi filters ext-proc

### DIFF
--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -13,6 +13,7 @@ services:
       - ./envoy.yml:/etc/envoy/envoy.yml
 
   extproc-go:
+    command: ["./extproc-go", "--filters", "reject"]
     build:
       context: ../
       dockerfile: examples/Dockerfile
@@ -20,6 +21,29 @@ services:
     ports:
       - 8080:8080 # extproc: http echo
       - 8081:8081 # extproc: grpc server
+    develop:
+      watch:
+        - action: rebuild
+          path: "../"
+          ignore:
+            - "**/*_test.go"
+            - "**/*.yml"
+            - "**/*.yaml"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://extproc-go:8080/headers"]
+      interval: 5s
+      timeout: 10s
+      retries: 60
+
+  observer:
+    command: ["./extproc-go", "--filters", "observe"]
+    build:
+      context: ../
+      dockerfile: examples/Dockerfile
+    hostname: host.testcontainers.observer.internal
+    ports:
+      - 8082:8080 # extproc: http echo
+      - 8083:8081 # extproc: grpc server
     develop:
       watch:
         - action: rebuild

--- a/examples/filters/observer.go
+++ b/examples/filters/observer.go
@@ -1,0 +1,31 @@
+package filters
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+
+	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/getyourguide/extproc-go/filter"
+)
+
+type Observer struct {
+	filter.NoOpFilter
+}
+
+var _ filter.Filter = &Observer{}
+
+func (f *Observer) ResponseHeaders(ctx context.Context, crw *filter.CommonResponseWriter, req *filter.RequestContext) (*extproc.ProcessingResponse_ImmediateResponse, error) {
+	slog.Info("====== ResponseHeaders ======")
+	slog.Info("saw request response", "request_id", req.RequestID())
+	slog.Info("request headers")
+	for k, v := range req.RequestHeaders {
+		slog.Info(k, "values", strings.Join(v, ","))
+	}
+
+	slog.Info("response headers")
+	for k, v := range req.ResponseHeaders {
+		slog.Info(k, "values", strings.Join(v, ","))
+	}
+	return nil, nil
+}

--- a/examples/filters/rejector.go
+++ b/examples/filters/rejector.go
@@ -1,0 +1,24 @@
+package filters
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/getyourguide/extproc-go/filter"
+)
+
+// Rejector is a filter that immediately responds with a 403
+type Rejector struct {
+	filter.NoOpFilter
+}
+
+var _ filter.Filter = &Rejector{}
+
+func (f *Rejector) RequestHeaders(ctx context.Context, crw *filter.CommonResponseWriter, req *filter.RequestContext) (*extproc.ProcessingResponse_ImmediateResponse, error) {
+	slog.Info("rejecting a request", "request", req.RequestID())
+	return filter.NewImmediateResponseBuilder().
+		HTTPStatus(http.StatusForbidden).
+		ImmediateResponse(), nil
+}

--- a/examples/filters/testdata/setcookie.yml
+++ b/examples/filters/testdata/setcookie.yml
@@ -1,4 +1,3 @@
----
 name: it should set set-cookie headers with SameSite=Lax and HttpOnly
 input:
   headers:

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,17 +2,44 @@ package main
 
 import (
 	"context"
+	"flag"
+	"log"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/getyourguide/extproc-go/examples/filters"
+	"github.com/getyourguide/extproc-go/filter"
 	"github.com/getyourguide/extproc-go/server"
 )
 
 func main() {
-	slog.Info("starting server")
+	var enabledFiltersParam string
+	flag.StringVar(&enabledFiltersParam, "filters", "", "the filters to enable")
+	flag.Parse()
+	enabledFilters := strings.Split(enabledFiltersParam, ",")
+
+	if len(enabledFilters) == 0 {
+		log.Fatal("no filters enabled: pass --filters x,y,z to set filters to enable")
+	}
+
+	filterMap := map[string]filter.Filter{
+		"reject":  &filters.Rejector{},
+		"observe": &filters.Observer{},
+	}
+
+	var serverFilters []filter.Filter
+	for _, filterName := range enabledFilters {
+		f, ok := filterMap[filterName]
+		if !ok {
+			log.Fatalf("no filter called %s exists", filterName)
+		}
+		serverFilters = append(serverFilters, f)
+	}
+
+	slog.Info("starting server", "filters", enabledFilters)
 	err := server.New(context.Background(),
-		server.WithFilters(&filters.SameSiteLaxMode{}),
+		server.WithFilters(serverFilters...),
 		server.WithEcho(),
 	).Serve()
 

--- a/test/containers/envoy/envoy.yml
+++ b/test/containers/envoy/envoy.yml
@@ -32,6 +32,27 @@ static_resources:
                           route:
                             cluster: echo
                 http_filters:
+                  - name: events
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+                      message_timeout: 5s
+                      failure_mode_allow: false
+                      allow_mode_override: true
+                      observability_mode: true
+                      mutation_rules:
+                        allow_all_routing: true
+                        allow_envoy: true
+                      processing_mode:
+                        request_header_mode: SEND
+                        response_header_mode: SEND
+                        request_body_mode: NONE
+                        response_body_mode: NONE
+                        request_trailer_mode: SKIP
+                        response_trailer_mode: SKIP
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: events
+                        timeout: 5s
                   - name: extproc-go
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
@@ -71,6 +92,23 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
+    - name: events
+      connect_timeout: 1s
+      type: STRICT_DNS
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: events
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: host.testcontainers.observer.internal
+                      port_value: 8081
     - name: extproc-go
       connect_timeout: 1s
       type: STRICT_DNS


### PR DESCRIPTION
⚠️ just a demo, not for merging ⚠️ 

Method: `docker compose up`

`cd examples && go test ./... -count=1 -v`

```
observer-1    | 2025/01/13 15:39:39 INFO starting server filters=[observe]
extproc-go-1  | 2025/01/13 15:39:39 INFO starting server filters=[reject]
extproc-go-1  | 2025/01/13 15:39:39 INFO starting grpc server address=:8081
extproc-go-1  | 2025/01/13 15:39:39 INFO starting http server address=:8080
observer-1    | 2025/01/13 15:39:39 INFO starting http server address=:8080
observer-1    | 2025/01/13 15:39:39 INFO starting grpc server address=:8081
extproc-go-1  | 2025/01/13 15:39:45 INFO rejecting a request request=8e6a9838-623d-9c75-b7a1-ac758193390e
observer-1    | 2025/01/13 15:39:45 INFO ====== ResponseHeaders ======
observer-1    | 2025/01/13 15:39:45 INFO saw request response request_id=8e6a9838-623d-9c75-b7a1-ac758193390e
observer-1    | 2025/01/13 15:39:45 INFO request headers
observer-1    | 2025/01/13 15:39:45 INFO Accept-Encoding values=gzip
observer-1    | 2025/01/13 15:39:45 INFO X-Forwarded-Proto values=http
observer-1    | 2025/01/13 15:39:45 INFO X-Request-Id values=8e6a9838-623d-9c75-b7a1-ac758193390e
observer-1    | 2025/01/13 15:39:45 INFO :authority values=127.0.0.1:10000
observer-1    | 2025/01/13 15:39:45 INFO :method values=GET
observer-1    | 2025/01/13 15:39:45 INFO :scheme values=http
observer-1    | 2025/01/13 15:39:45 INFO Path values="/response-headers?set-cookie=session=my-session&set-cookie=auth=d2h5IHNvIGN1cmlvdXM/Cg=="
observer-1    | 2025/01/13 15:39:45 INFO :path values="/response-headers?set-cookie=session=my-session&set-cookie=auth=d2h5IHNvIGN1cmlvdXM/Cg=="
observer-1    | 2025/01/13 15:39:45 INFO User-Agent values=Go-http-client/1.1
observer-1    | 2025/01/13 15:39:45 INFO response headers
observer-1    | 2025/01/13 15:39:45 INFO :status values=403
```