### PR TITLE
fix: response headers should run in reverse order

### DIFF
--- a/filter/request.go
+++ b/filter/request.go
@@ -191,8 +191,6 @@ func (m *Metadata) Get(key any) any {
 	return m.m[key]
 }
 
-type RequestContextOption func(*RequestContext)
-
 func NewRequestContext() *RequestContext {
 	req := &RequestContext{
 		RequestHeaders:  make(http.Header),

--- a/service/options.go
+++ b/service/options.go
@@ -16,7 +16,6 @@ func (o optionFunc) apply(f *ExtProcessor) {
 	o(f)
 }
 
-// WithLogger configures the service with a logger
 func WithLogger(log logr.Logger) Option {
 	return optionFunc(func(svc *ExtProcessor) {
 		svc.log = log

--- a/service/service.go
+++ b/service/service.go
@@ -197,7 +197,8 @@ func (svc *ExtProcessor) responseHeadersMessage(ctx context.Context, req *filter
 	}
 	crw := filter.NewCommonResponseWriter(req.ResponseHeaders)
 
-	for _, f := range svc.filters {
+	for i := len(svc.filters) - 1; i >= 0; i-- {
+		f := svc.filters[i]
 		select {
 		case <-ctx.Done():
 			return nil

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -30,6 +30,10 @@ func TestMain(m *testing.M) {
 	}
 }
 
+func TestRequestHeaders(t *testing.T) {
+	runServiceTest(t, "testdata/request_header_order.yml")
+}
+
 func TestResponseHeaders(t *testing.T) {
 	runServiceTest(t, "testdata/response_header_order.yml")
 }

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1,0 +1,73 @@
+package service_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/getyourguide/extproc-go/filter"
+	"github.com/getyourguide/extproc-go/server"
+	"github.com/getyourguide/extproc-go/test"
+	"github.com/getyourguide/extproc-go/test/containers/envoy"
+	filtertest "github.com/getyourguide/extproc-go/test/filter"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"sigs.k8s.io/yaml"
+)
+
+var envoyProxy *envoy.TestContainer
+
+func TestMain(m *testing.M) {
+	ctx := context.Background()
+	envoyProxy = envoy.NewTestContainer()
+	if err := envoyProxy.Run(ctx, "istio/proxyv2:1.24.2"); err != nil {
+		panic(err)
+	}
+	m.Run()
+	if err := testcontainers.TerminateContainer(envoyProxy); err != nil {
+		panic(err)
+	}
+}
+
+func TestResponseHeaders(t *testing.T) {
+	runServiceTest(t, "testdata/response_header_order.yml")
+}
+
+type serviceTest struct {
+	Filters   []filtertest.Configuration `json:"filters"`
+	TestCases test.TestCases             `json:"tests"`
+}
+
+func runServiceTest(t *testing.T, fileName string) {
+	f, err := os.ReadFile(fileName)
+	require.NoError(t, err)
+
+	var tt serviceTest
+	err = yaml.Unmarshal(f, &tt)
+	require.NoError(t, err)
+
+	var filters []filter.Filter
+	for _, cfg := range tt.Filters {
+		filters = append(filters, &filtertest.Filter{
+			Configuration: cfg,
+		})
+	}
+
+	srv := server.New(context.Background(),
+		server.WithEcho(),
+		server.WithFilters(filters...),
+	)
+	go func() {
+		require.NoError(t, srv.Serve())
+	}()
+	waitTimeout := 5 * time.Second
+
+	err = server.WaitReady(srv, waitTimeout)
+	require.NoError(t, err)
+
+	tt.TestCases.Run(t,
+		test.WithURL(envoyProxy.URL.String()),
+	)
+	require.NoError(t, srv.Stop())
+}

--- a/service/testdata/request_header_order.yml
+++ b/service/testdata/request_header_order.yml
@@ -1,0 +1,15 @@
+filters:
+- requestHeaders:
+    headerMutation:
+      set:
+        x-res-header-a: first-filter
+- requestHeaders:
+    headerMutation:
+      set:
+        x-res-header-a: last-filter
+tests:
+- name: it should run filters in order for requestHeaders message
+  expect:
+    requestHeaders:
+      - name: x-req-header-a
+        exact: last-filter

--- a/service/testdata/request_header_order.yml
+++ b/service/testdata/request_header_order.yml
@@ -2,13 +2,13 @@ filters:
 - requestHeaders:
     headerMutation:
       set:
-        x-res-header-a: first-filter
+        x-req-header-a: first-filter
 - requestHeaders:
     headerMutation:
       set:
-        x-res-header-a: last-filter
+        x-req-header-a: last-filter
 tests:
-- name: it should run filters in order for requestHeaders message
+- name: it should run filters in order for request headers message
   expect:
     requestHeaders:
       - name: x-req-header-a

--- a/service/testdata/response_header_order.yml
+++ b/service/testdata/response_header_order.yml
@@ -1,0 +1,15 @@
+filters:
+- response_headers:
+    header_mutation:
+      set:
+        x-res-header-a: first-filter
+- response_headers:
+    header_mutation:
+      set:
+        x-res-header-a: last-filter
+tests:
+- name: it should run filters in reverse order for response_headers message
+  expect:
+    responseHeaders:
+      - name: x-res-header-a
+        exact: first-filter

--- a/service/testdata/response_header_order.yml
+++ b/service/testdata/response_header_order.yml
@@ -8,7 +8,7 @@ filters:
       set:
         x-res-header-a: last-filter
 tests:
-- name: it should run filters in reverse order for responseHeaders message
+- name: it should run filters in reverse order for response headers message
   expect:
     responseHeaders:
       - name: x-res-header-a

--- a/service/testdata/response_header_order.yml
+++ b/service/testdata/response_header_order.yml
@@ -1,14 +1,14 @@
 filters:
-- response_headers:
-    header_mutation:
+- responseHeaders:
+    headerMutation:
       set:
         x-res-header-a: first-filter
-- response_headers:
-    header_mutation:
+- responseHeaders:
+    headerMutation:
       set:
         x-res-header-a: last-filter
 tests:
-- name: it should run filters in reverse order for response_headers message
+- name: it should run filters in reverse order for responseHeaders message
   expect:
     responseHeaders:
       - name: x-res-header-a

--- a/test/containers/envoy/envoy_test.go
+++ b/test/containers/envoy/envoy_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestRunContainer(t *testing.T) {
 	container := envoy.NewTestContainer()
-	u, err := container.Run(context.Background(), "istio/proxyv2:1.24.2")
+	err := container.Run(context.Background(), "istio/proxyv2:1.24.2")
 	defer testcontainers.CleanupContainer(t, container)
 
 	require.NoError(t, err)
-	require.Contains(t, u.String(), "http://localhost:")
+	require.Contains(t, container.URL.String(), "http://localhost:")
 }

--- a/test/filter/filter.go
+++ b/test/filter/filter.go
@@ -12,13 +12,13 @@ import (
 
 type Configuration struct {
 	RequestHeaders struct {
-		HeaderMutation    headerMutation     `json:"header_mutation"`
-		ImmediateResponse *immediateResponse `json:"immediate_response"`
-	} `json:"request_headers"`
+		HeaderMutation    headerMutation     `json:"headerMutation"`
+		ImmediateResponse *immediateResponse `json:"immediateResponse"`
+	} `json:"requestHeaders"`
 	ResponseHeaders struct {
-		HeaderMutation    headerMutation     `json:"header_mutation"`
-		ImmediateResponse *immediateResponse `json:"immediate_response"`
-	} `json:"response_headers"`
+		HeaderMutation    headerMutation     `json:"headerMutation"`
+		ImmediateResponse *immediateResponse `json:"immediateResponse"`
+	} `json:"responseHeaders"`
 }
 
 type immediateResponse struct {

--- a/test/filter/filter.go
+++ b/test/filter/filter.go
@@ -1,0 +1,92 @@
+package filtertest
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	extproc "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
+	"github.com/getyourguide/extproc-go/filter"
+	"sigs.k8s.io/yaml"
+)
+
+type Configuration struct {
+	RequestHeaders struct {
+		HeaderMutation    headerMutation     `json:"header_mutation"`
+		ImmediateResponse *immediateResponse `json:"immediate_response"`
+	} `json:"request_headers"`
+	ResponseHeaders struct {
+		HeaderMutation    headerMutation     `json:"header_mutation"`
+		ImmediateResponse *immediateResponse `json:"immediate_response"`
+	} `json:"response_headers"`
+}
+
+type immediateResponse struct {
+	Status int    `json:"status"`
+	Body   string `json:"body"`
+}
+type headerMutation struct {
+	RemoveHeader []string          `json:"remove"`
+	SetHeader    map[string]string `json:"set"`
+	ApendHeader  map[string]string `json:"append"`
+}
+
+type Filter struct {
+	Configuration Configuration
+}
+
+var _ filter.Filter = &Filter{}
+
+func (f *Filter) RequestHeaders(ctx context.Context, crw *filter.CommonResponseWriter, req *filter.RequestContext) (*extproc.ProcessingResponse_ImmediateResponse, error) {
+	if f.Configuration.RequestHeaders.ImmediateResponse != nil {
+		return filter.NewImmediateResponseBuilder().
+			HTTPStatus(f.Configuration.RequestHeaders.ImmediateResponse.Status).
+			Body([]byte(f.Configuration.RequestHeaders.ImmediateResponse.Body)).
+			ImmediateResponse(), nil
+	}
+	crw.RemoveHeaders(f.Configuration.RequestHeaders.HeaderMutation.RemoveHeader...)
+	for k, v := range f.Configuration.RequestHeaders.HeaderMutation.SetHeader {
+		crw.SetHeader(k, v)
+
+	}
+	for k, v := range f.Configuration.RequestHeaders.HeaderMutation.ApendHeader {
+		crw.AppendHeader(k, v)
+	}
+	return nil, nil
+}
+
+func (f *Filter) ResponseHeaders(ctx context.Context, crw *filter.CommonResponseWriter, req *filter.RequestContext) (*extproc.ProcessingResponse_ImmediateResponse, error) {
+	if f.Configuration.ResponseHeaders.ImmediateResponse != nil {
+		return filter.NewImmediateResponseBuilder().
+			HTTPStatus(f.Configuration.ResponseHeaders.ImmediateResponse.Status).
+			Body([]byte(f.Configuration.ResponseHeaders.ImmediateResponse.Body)).
+			ImmediateResponse(), nil
+	}
+	crw.RemoveHeaders(f.Configuration.ResponseHeaders.HeaderMutation.RemoveHeader...)
+	for k, v := range f.Configuration.ResponseHeaders.HeaderMutation.SetHeader {
+		crw.SetHeader(k, v)
+	}
+	for k, v := range f.Configuration.ResponseHeaders.HeaderMutation.ApendHeader {
+		crw.AppendHeader(k, v)
+	}
+	return nil, nil
+}
+
+func New(config []byte) (*Filter, error) {
+	var cfg Configuration
+	err := yaml.Unmarshal(config, &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("could not unmarshal file: %w", err)
+	}
+	return &Filter{
+		Configuration: cfg,
+	}, nil
+}
+
+func NewFromFile(file string) (*Filter, error) {
+	f, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("could not read file: %w", err)
+	}
+	return New(f)
+}

--- a/test/filter/filter.go
+++ b/test/filter/filter.go
@@ -28,7 +28,7 @@ type immediateResponse struct {
 type headerMutation struct {
 	RemoveHeader []string          `json:"remove"`
 	SetHeader    map[string]string `json:"set"`
-	ApendHeader  map[string]string `json:"append"`
+	AppendHeader map[string]string `json:"append"`
 }
 
 type Filter struct {
@@ -49,7 +49,7 @@ func (f *Filter) RequestHeaders(ctx context.Context, crw *filter.CommonResponseW
 		crw.SetHeader(k, v)
 
 	}
-	for k, v := range f.Configuration.RequestHeaders.HeaderMutation.ApendHeader {
+	for k, v := range f.Configuration.RequestHeaders.HeaderMutation.AppendHeader {
 		crw.AppendHeader(k, v)
 	}
 	return nil, nil
@@ -66,7 +66,7 @@ func (f *Filter) ResponseHeaders(ctx context.Context, crw *filter.CommonResponse
 	for k, v := range f.Configuration.ResponseHeaders.HeaderMutation.SetHeader {
 		crw.SetHeader(k, v)
 	}
-	for k, v := range f.Configuration.ResponseHeaders.HeaderMutation.ApendHeader {
+	for k, v := range f.Configuration.ResponseHeaders.HeaderMutation.AppendHeader {
 		crw.AppendHeader(k, v)
 	}
 	return nil, nil


### PR DESCRIPTION
Follow envoy behavior of running filters in reverse order in the response stream phases https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/http/http_filters#filter-ordering