### PR TITLE
tracing: add span on stream complete

### DIFF
--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -20,6 +20,11 @@ services:
     ports:
       - 8080:8080 # extproc: http echo
       - 8081:8081 # extproc: grpc server
+    environment:
+      DD_AGENT_HOST: datadog
+      DD_TRACE_AGENT_PORT: 8126
+      DD_ENV: development
+      DD_SERVICE: extproc-go
     develop:
       watch:
         - action: rebuild
@@ -33,3 +38,20 @@ services:
       interval: 5s
       timeout: 10s
       retries: 60
+
+  datadog:
+    environment:
+      - DD_API_KEY
+      - DD_APP_KEY
+      - DD_APM_ENABLED=true
+      - DD_ENV=development
+      - DD_CLUSTER=development
+    ports:
+      - 8126:8126
+    image: datadog/agent
+    profiles:
+      - dev
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "/proc/:/host/proc/:ro"
+      - "/sys/fs/cgroup/:/host/sys/fs/cgroup:ro"

--- a/examples/compose.yaml
+++ b/examples/compose.yaml
@@ -20,11 +20,6 @@ services:
     ports:
       - 8080:8080 # extproc: http echo
       - 8081:8081 # extproc: grpc server
-    environment:
-      DD_AGENT_HOST: datadog
-      DD_TRACE_AGENT_PORT: 8126
-      DD_ENV: development
-      DD_SERVICE: extproc-go
     develop:
       watch:
         - action: rebuild
@@ -38,20 +33,3 @@ services:
       interval: 5s
       timeout: 10s
       retries: 60
-
-  datadog:
-    environment:
-      - DD_API_KEY
-      - DD_APP_KEY
-      - DD_APM_ENABLED=true
-      - DD_ENV=development
-      - DD_CLUSTER=development
-    ports:
-      - 8126:8126
-    image: datadog/agent
-    profiles:
-      - dev
-    volumes:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "/proc/:/host/proc/:ro"
-      - "/sys/fs/cgroup/:/host/sys/fs/cgroup:ro"

--- a/server/server.go
+++ b/server/server.go
@@ -59,6 +59,12 @@ func WithFilters(f ...filter.Filter) Option {
 	}
 }
 
+func WithServiceOptions(opts ...service.Option) Option {
+	return func(s *Server) {
+		s.serviceOpts = append(s.serviceOpts, opts...)
+	}
+}
+
 func WithGrpcServer(server *grpc.Server, network string, address string) Option {
 	return func(s *Server) {
 		s.grpcServer = server

--- a/test/containers/envoy/envoy.yml
+++ b/test/containers/envoy/envoy.yml
@@ -116,12 +116,20 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      address: localhost
+                      address: datadog
                       port_value: 8126
 
 overload_manager:
   resource_monitors:
-    - name: "envoy.resource_monitors.global_downstream_max_connections"
+    - name: envoy.resource_monitors.global_downstream_max_connections
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 1000
+
+tracing:
+  http:
+    name: envoy.tracers.datadog
+    typed_config:
+      "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
+      collector_cluster: datadog
+      service_name: extproc-go

--- a/test/containers/envoy/envoy.yml
+++ b/test/containers/envoy/envoy.yml
@@ -105,31 +105,9 @@ static_resources:
                       address: host.testcontainers.internal
                       port_value: 8080
 
-    - name: datadog
-      connect_timeout: 1s
-      type: STRICT_DNS
-      lb_policy: round_robin
-      load_assignment:
-        cluster_name: datadog
-        endpoints:
-          - lb_endpoints:
-              - endpoint:
-                  address:
-                    socket_address:
-                      address: datadog
-                      port_value: 8126
-
 overload_manager:
   resource_monitors:
     - name: envoy.resource_monitors.global_downstream_max_connections
       typed_config:
         "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
         max_active_downstream_connections: 1000
-
-tracing:
-  http:
-    name: envoy.tracers.datadog
-    typed_config:
-      "@type": type.googleapis.com/envoy.config.trace.v3.DatadogConfig
-      collector_cluster: datadog
-      service_name: extproc-go


### PR DESCRIPTION
adds span on stream complete callback. To work with datadog one should setup as:

```go
package main

import (
	"context"
	"log/slog"
	"os"

	"github.com/getyourguide/extproc-go/examples/filters"
	"github.com/getyourguide/extproc-go/server"
	"github.com/getyourguide/extproc-go/service"
	"go.opentelemetry.io/otel"
	"go.opentelemetry.io/otel/propagation"
	"google.golang.org/grpc"

	ddotel "github.com/DataDog/dd-trace-go/v2/ddtrace/opentelemetry"
	grpctrace "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
)

func main() {
	slog.Info("starting server")

	provider := ddotel.NewTracerProvider()
	defer provider.Shutdown()
	tracer := provider.Tracer("")
	otel.SetTracerProvider(provider)
	otel.SetTextMapPropagator(propagation.TraceContext{})

	sh := grpctrace.NewServerHandler()
	grpcSrv := grpc.NewServer(grpc.StatsHandler(sh))

	err := server.New(context.Background(),
		server.WithGrpcServer(grpcSrv, "tcp", ":8081"),
		server.WithServiceOptions(
			service.WithFilters(&filters.SameSiteLaxMode{}),
			service.WithTracer(tracer),
		),
		server.WithEcho(),
	).Serve()

	if err != nil {
		slog.Error("failed to start server", "error", err)
		os.Exit(1)
	}
}
```

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/9b85a42a-1ec2-4285-9941-8f5074affc2a" />