### PR TITLE
SEC-3421: Migrate Go version from 1.23.4 to 1.25.0

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-bullseye AS build
+FROM golang:1.25-bullseye AS build
 
 WORKDIR /build
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getyourguide/extproc-go
 
-go 1.23.4
+go 1.25.0
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.4


### PR DESCRIPTION
Updated go version